### PR TITLE
Drop allowUniversalAccessFromFileURLs in applyBaseV2WebSettings

### DIFF
--- a/shared/src/commonMain/kotlin/io/github/v2compose/ui/webview/WebViewSettings.kt
+++ b/shared/src/commonMain/kotlin/io/github/v2compose/ui/webview/WebViewSettings.kt
@@ -4,7 +4,12 @@ import com.multiplatform.webview.setting.WebSettings
 
 internal fun WebSettings.applyBaseV2WebSettings() {
     isJavaScriptEnabled = true
-    allowUniversalAccessFromFileURLs = true
+    // allowUniversalAccessFromFileURLs only takes effect when the main
+    // frame is a file:// URL. WebViewScreen and GoogleLoginScreen are
+    // both pointed at https URLs (v2ex pages, Google OAuth), so the
+    // flag is not load-bearing here and leaving it on is a CWE-200
+    // sandbox-escape vector if a file:// load ever lands in one of
+    // these WebViews.
     supportZoom = true
     androidWebSettings.domStorageEnabled = true
     androidWebSettings.useWideViewPort = true


### PR DESCRIPTION
Closes #18.

`applyBaseV2WebSettings` is the shared base WebView posture used by both `WebViewScreen` (the in-app v2ex page renderer) and `applyGoogleLoginWebSettings` (Google OAuth login). It set:

```kotlin
allowUniversalAccessFromFileURLs = true
```

That flag only takes effect when the main frame is a `file://` URL. Both consumers load https URLs (v2ex pages and Google OAuth respectively), so the flag is not load-bearing for any existing WebView. Leaving it on lets a stray `file://` load XHR any origin from the WebView (CWE-200).

### Change

Drop the line. Add a short inline comment recording the load-path assumption.

iOS and other Kotlin Multiplatform targets are unaffected because the flag is Android-specific in the multiplatform `WebSettings` abstraction.

Assisted-by: Claude (Anthropic)